### PR TITLE
Give hr_community_cost a hard-coded poop tag.

### DIFF
--- a/Mod Bot/Internal/MultiplayerNamePrefixManager.cs
+++ b/Mod Bot/Internal/MultiplayerNamePrefixManager.cs
@@ -55,6 +55,9 @@ namespace InternalModBot
 			if(!isDictionaryNullOrEmpty && playfabIDToCustomPrefixDictionary.ContainsKey(playfabID))
 				prefix += playfabIDToCustomPrefixDictionary[playfabID] + " ";
 
+			if(playfabID == "9EA644AC918B223F") // Hard-coded exception for hr_community_cost, who deserves a poop tag.
+				prefix = "<color=#402A05>[Poop Tag]</color>";
+
 			if (ModBotUserIdentifier.Instance != null && ModBotUserIdentifier.Instance.IsUsingModBot(playfabID))
 			{
 				if (!isDictionaryNullOrEmpty && playfabIDToCustomPrefixDictionary.TryGetValue(MOD_BOT_USER_KEY, out string modBotUserPrefix))


### PR DESCRIPTION
HR has proved that he really likes his poop tag. I've decided that simply having it in the database simply isn't enough. It absolutely **must** be a permanent part of Mod Bot itself. This completely bug-free pull request implements that life-changing feature.